### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Now you have three options:
 ---
 
 <sup>17.0</sup> Requires Dyalog APL version 17.0  
-<sup>17.0</sup> Requires Dyalog APL version 17.1
+<sup>17.1</sup> Requires Dyalog APL version 17.1


### PR DESCRIPTION
There seems to be a typo in the footnote of the readme: it says "<sup>17.0</sup> Requires Dyalog APL version 17.1", while "<sup>17.1</sup> Requires Dyalog APL version 17.1" is what you probably meant.
This commit fixes just that.